### PR TITLE
Updates dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ cache:
     directories:
     - $HOME/.m2
 language: java
+dist: trusty
 jdk:
     - oraclejdk8
+    - openjdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Changelog
 ========
 
-3.3
----
+Next Release
+------------
 - Update Maven and various Maven plugins
 - Update snakeyaml to 1.18 from 1.16 in YAML module
 - Update jackson to 2.8.8 from 2.6.3 in JSON module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,17 @@ Changelog
 
 3.2
 ---
+- Update Maven and various Maven plugins
+- Update snakeyaml to 1.18 from 1.16 in YAML module
+- Update jackson to 2.8.8 from 2.6.3 in JSON module
+- Update typesafe config to 1.3.1 from 1.3.0 in HOCON module
+- Update gson to 2.8.0 from 2.2.4 in GSON module
+- Move usage of removed Guava method
+
+3.2
+---
 - Allow Gson module to save empty files
--  Resolve configuration variables for hocon
+- Resolve configuration variables for hocon
 - Fix various issues on Windows
 - Correct file permissions
 - Improve error message when unable to find an appropriate TypeSerializer or when using raw types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ========
 
-3.2
+3.3
 ---
 - Update Maven and various Maven plugins
 - Update snakeyaml to 1.18 from 1.16 in YAML module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Next Release
 - Update jackson to 2.8.8 from 2.6.3 in JSON module
 - Update typesafe config to 1.3.1 from 1.3.0 in HOCON module
 - Update gson to 2.8.0 from 2.2.4 in GSON module
+- Update optional guice dependency to 4.1 from 4.0 in core
 - Move usage of removed Guava method
 
 3.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Make sure Maven is installed and from the project's directory (the root of this 
 <dependency>
     <groupId>ninja.leaping.configurate</groupId>
     <artifactId>configurate-hocon</artifactId>
-    <version>3.3</version> <!-- Update this with the most recent version -->
+    <version>3.2</version> <!-- Update this with the most recent version -->
 </dependency>
 ```
 This dependency statement is for the hocon format implementation. Other formats managed in this repository use the same group id and versioning.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Make sure Maven is installed and from the project's directory (the root of this 
 <dependency>
     <groupId>ninja.leaping.configurate</groupId>
     <artifactId>configurate-hocon</artifactId>
-    <version>3.1</version> <!-- Update this with the most recent version -->
+    <version>3.3</version> <!-- Update this with the most recent version -->
 </dependency>
 ```
 This dependency statement is for the hocon format implementation. Other formats managed in this repository use the same group id and versioning.

--- a/configurate-core/pom.xml
+++ b/configurate-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
       <groupId>ninja.leaping.configurate</groupId>
       <artifactId>configurate-parent</artifactId>
-      <version>3.2.1-SNAPSHOT</version>
+      <version>3.3</version>
   </parent>
 
   <artifactId>configurate-core</artifactId>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/configurate-core/pom.xml
+++ b/configurate-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
       <groupId>ninja.leaping.configurate</groupId>
       <artifactId>configurate-parent</artifactId>
-      <version>3.3</version>
+      <version>3.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>configurate-core</artifactId>

--- a/configurate-core/pom.xml
+++ b/configurate-core/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
+            <version>4.1.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * Handlers for various comment formats
@@ -95,11 +96,11 @@ public enum CommentHandlers implements CommentHandler {
         @Override
         public Collection<String> toComment(Collection<String> lines) {
             if (lines.size() == 1) {
-                return Collections2.transform(lines, input -> "/* " + input + " */");
+                return lines.stream().map(i -> "/* " + i + " */").collect(Collectors.toList());
             } else {
                 Collection<String> ret = new ArrayList<>();
                 ret.add("/*");
-                ret.addAll(Collections2.transform(lines, input -> " * " + input));
+                ret.addAll(lines.stream().map(i -> " * " + i).collect(Collectors.toList()));
                 ret.add(" */");
                 return ret;
             }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
@@ -42,7 +42,7 @@ public class TypeSerializerCollection {
         TypeSerializer<?> serial = typeMatches.get(type);
         if (serial == null) {
             for (Map.Entry<TypeToken<?>, TypeSerializer<?>> ent : typeMatches.entrySet()) {
-                if (ent.getKey().isAssignableFrom(type)) {
+                if (ent.getKey().isSupertypeOf(type)) {
                     serial = ent.getValue();
                     typeMatches.put(type, serial);
                     break;

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -127,7 +127,7 @@ public class TypeSerializers {
 
             Enum ret;
             try {
-                ret = Enum.valueOf(type.getRawType().asSubclass(Enum.class), value.getString().toUpperCase());
+                ret = Enum.valueOf((Class) type.getRawType().asSubclass(Enum.class), value.getString().toUpperCase());
             } catch (IllegalArgumentException e) {
                 throw new ObjectMappingException("Invalid enum constant provided for " + value.getKey() + ": Expected a value of enum " + type + ", got " + enumConstant);
             }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -127,7 +127,7 @@ public class TypeSerializers {
 
             Enum ret;
             try {
-                ret = Enum.valueOf((Class) type.getRawType().asSubclass(Enum.class), value.getString().toUpperCase());
+                ret = Enum.valueOf(type.getRawType().asSubclass(Enum.class), value.getString().toUpperCase());
             } catch (IllegalArgumentException e) {
                 throw new ObjectMappingException("Invalid enum constant provided for " + value.getKey() + ": Expected a value of enum " + type + ", got " + enumConstant);
             }

--- a/configurate-gson/pom.xml
+++ b/configurate-gson/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.3</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/configurate-gson/pom.xml
+++ b/configurate-gson/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>ninja.leaping.configurate</groupId>

--- a/configurate-hocon/pom.xml
+++ b/configurate-hocon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.3</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/configurate-hocon/pom.xml
+++ b/configurate-hocon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>ninja.leaping.configurate</groupId>

--- a/configurate-json/pom.xml
+++ b/configurate-json/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.3</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/configurate-json/pom.xml
+++ b/configurate-json/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.3</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>ninja.leaping.configurate</groupId>

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
@@ -174,7 +174,7 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
                     parseValue(parser, node.getNode(parser.getCurrentName()));
             }
         }
-            throw new JsonParseException("Reached end of stream with unclosed array!", parser.getCurrentLocation());
+            throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());
     }
 
     @Override

--- a/configurate-yaml/pom.xml
+++ b/configurate-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.3</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/configurate-yaml/pom.xml
+++ b/configurate-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.16</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>ninja.leaping.configurate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ninja.leaping.configurate</groupId>
     <artifactId>configurate-parent</artifactId>
-    <version>3.3</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Configurate Parent</name>
     <description>A simple configuration library for Java applications that can handle a variety of formats and

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ninja.leaping.configurate</groupId>
     <artifactId>configurate-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3</version>
     <packaging>pom</packaging>
     <name>Configurate Parent</name>
     <description>A simple configuration library for Java applications that can handle a variety of formats and
@@ -80,7 +80,7 @@
     </modules>
 
     <prerequisites>
-        <maven>3.0.4</maven>
+        <maven>3.5.0</maven>
     </prerequisites>
 
 
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4</version>
                 <reportSets>
                     <reportSet><!-- by default, id = "default" -->
                         <reports><!-- select non-aggregate reports -->
@@ -106,7 +106,7 @@
                 </reportSets>
                 <configuration>
                     <links>
-                        <link>http://docs.guava-libraries.googlecode.com/git-history/v17.0/javadoc</link>
+                        <link>http://google.github.io/guava/releases/21.0/api/docs/</link>
                     </links>
                 </configuration>
             </plugin>
@@ -125,7 +125,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.1</version>
                 <configuration>
                     <target>1.8</target>
                     <source>1.8</source>
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.11</version>
+                <version>3.0</version>
                 <configuration>
                     <header>LICENSE_HEADER</header>
                     <includes>
@@ -154,7 +154,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.6</version>
                 <executions>
                     <execution>
                         <inherited>no</inherited>
@@ -198,7 +198,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -211,7 +211,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -238,7 +238,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.6</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
This goes ahead and updates a lot of the dependencies. I was originally going to just update Guava and GSON for Sponge compatibility in 1.12 as Guava introduced a breaking change, but I thought updating other dependencies wouldn't hurt. 

I did have one issue though that's why this is WIP, as I cannot get the following HOCON test to pass, so Configurate will not compile(So this test seems to only not pass locally on my Windows machine):

![image](https://cloud.githubusercontent.com/assets/18372958/25204451/35acb104-2523-11e7-9f51-f897f107c9d7.png)

It appears the output does mess up the comment. Here is the surefire report:
https://gist.github.com/Meronat/5a5e3722e7b9636aa2b4e39b7bc57f1c