### PR TITLE
Fix reading of multi-line HOCON comments

### DIFF
--- a/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
+++ b/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
  * A loader for HOCON (Hodor)-formatted configurations, using the typesafe config library for parsing
  */
 public class HoconConfigurationLoader extends AbstractConfigurationLoader<CommentedConfigurationNode> {
-    public static final Pattern CRLF_MATCH = Pattern.compile("\r\n?");
+    private static final Pattern CRLF_MATCH = Pattern.compile("\r?");
     private final ConfigRenderOptions render;
     private final ConfigParseOptions parse;
 


### PR DESCRIPTION
Previously, The `HoconConfigurationLoaderTest#testSplitLineCommentInput` would fail, as the multiline comment for

```
# Name of the AI
# This is currently set to the name of the best AI
ai-name = GLaDOS
```

would be parsed by configurate as 

```
# Name of the AI This is currently set to the name of the best AI, ai-name=GLaDOS
```

instead of 

```
# Name of the AI, # This is currently set to the name of the best AI, ai-name=GLaDOS
```

This is because the `CRLF_MATCH` pattern in `HoconConfigurationLoader` removed the newline character here:

```java
public static final Pattern CRLF_MATCH = Pattern.compile("\r\n?");
```

```java
node.setComment(CRLF_MATCH.matcher(Joiner.on('\n').join(value.origin().comments())).replaceAll(""));
```

This PR fixes this behaviour, by changing the pattern to only match the tab character.

Test output before:
```
Running ninja.leaping.configurate.hocon.HoconConfigurationLoaderTest
Example sourced from https://github.com/zml2008/configurate/issues/17
Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.34 sec <<< FAILURE!
testSplitLineCommentInput(ninja.leaping.configurate.hocon.HoconConfigurationLoaderTest)  Time elapsed: 0.021 sec  <<< FAILURE!
java.lang.AssertionError: expected:<[# Example sourced from https://github.com/zml2008/configurate/issues/17, , # Name of the AI, # This is currently set to the name of the best AI, ai-name=GLaDOS, # The color of tomato, color=RED, # Time until server explodes, timeout=30, # The Version of this config. This is a one-line comment., version=7]> but was:<[# Example sourced from https://github.com/zml2008/configurate/issues/17, , # Name of the AI This is currently set to the name of the best AI, ai-name=GLaDOS, # The color of tomato, color=RED, # Time until server explodes, timeout=30, # The Version of this config. This is a one-line comment., version=7]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at ninja.leaping.configurate.hocon.HoconConfigurationLoaderTest.testSplitLineCommentInput(HoconConfigurationLoaderTest.java:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```

Test output after:
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running ninja.leaping.configurate.hocon.HoconConfigurationLoaderTest
Example sourced from https://github.com/zml2008/configurate/issues/17
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.461 sec

Results :

Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```